### PR TITLE
fixed the linking of contracts to the inheritance works

### DIFF
--- a/HumanStandardToken.sol
+++ b/HumanStandardToken.sol
@@ -17,11 +17,6 @@ import "StandardToken.sol";
 
 contract HumanStandardToken is StandardToken {
 
-    function () {
-        //if ether is sent to this address, send it back.
-        throw;
-    }
-
     /* Public variables of the token */
 
     /*

--- a/TokenCreator.sol
+++ b/TokenCreator.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.0;
 
 import "CharityToken.sol";
 
-contract TokenCreator {
+contract TokenCreator is CharityToken {
 
     uint public startFundingTime;
     uint public endFundingTime;
@@ -32,7 +32,7 @@ contract TokenCreator {
         vaultContract = _vaultContract;
     }
 
-    function ()  payable {
+    function () payable {
         proxyPayment(msg.sender);
     }
 
@@ -51,11 +51,4 @@ contract TokenCreator {
         if (!vaultContract.send(msg.value)) throw;
         if (!tokenContract.createTokens(_owner, msg.value)) throw;
     }
-
-    function seal() {
-        if (now < endFundingTime) throw;
-        tokenContract.seal();
-        suicide(vaultContract);
-    }
-
 }


### PR DESCRIPTION
Was it your intention to do `contract TokenCreator is CharityToken {` but you forgot to do it. I made these changes and had to remove some other functions to prevent them from being created twice. 
